### PR TITLE
Fix ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/projects/ngx-pagination-data-source/src/lib/pagination-data-source.ts
+++ b/projects/ngx-pagination-data-source/src/lib/pagination-data-source.ts
@@ -2,7 +2,7 @@ import {SimpleDataSource} from './simple-data-source'
 import {Page, PaginationEndpoint, Sort} from './page'
 import {indicate} from './indicate'
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
-import {map, shareReplay, startWith, switchMap, tap} from 'rxjs/operators';
+import {map, shareReplay, startWith, switchMap, tap, delay} from 'rxjs/operators';
 
 
 export class PaginationDataSource<T, Q = Partial<T>> implements SimpleDataSource<T> {
@@ -29,6 +29,7 @@ export class PaginationDataSource<T, Q = Partial<T>> implements SimpleDataSource
     this.page$ = param$.pipe(
       switchMap(([query, sort]) => this.pageNumber.pipe(
         startWith(initialPage && firstCall ? initialPage : 0),
+        delay(0),
         tap(() => firstCall = false),
         switchMap(page => this.endpoint({page, sort, size: this.pageSize}, query)
           .pipe(indicate(this.loading))


### PR DESCRIPTION
There's an ExpressionChangedAfterItHasBeenCheckedError when using this lib and trying to use something like `*ngIf="dataSource.loading$"` in a template.

How to reproduce: Go to the [Example StackBlitz](https://stackblitz.com/github/nilsmehlhorn/ngx-pagination-data-source-example) and open StackBlitz's console tab. It will show:

```
ERROR

Error: NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it 
was checked. Previous value: 'null'. Current value: 'true'. Find more at 
https://angular.io/errors/NG0100
```

This PR uses the fix explained in the [Angular Debugging "Expression has changed after it was checked": Simple Explanation (and Fix)](https://blog.angular-university.io/angular-debugging/) blog post.

The article also mentions that the ideal solution would be to initialize the query inside a `ngOnInit()`, but I couldn't find a clean and straight-forward way of doing this since if we just declare the variable:

```typescript
dataSource: PaginationDataSource<Student, StudentQuery>;
```

we get a `Property 'dataSource' has no initializer and is not definitely assigned in the constructor.` error.