### PR TITLE
Implement debounceTime in queries

### DIFF
--- a/projects/ngx-pagination-data-source/src/lib/pagination-data-source.ts
+++ b/projects/ngx-pagination-data-source/src/lib/pagination-data-source.ts
@@ -24,7 +24,13 @@ export class PaginationDataSource<T, Q = Partial<T>> implements SimpleDataSource
     let firstCall = true;
     this.query = new BehaviorSubject<Q>(initialQuery)
     this.sort = new BehaviorSubject<Sort<T>>(initialSort)
-    const param$ = combineLatest([this.query, this.sort])
+    const param$ = combineLatest([
+      this.query.pipe(
+        debounceTime(400),
+        distinctUntilChanged()
+      ),
+      this.sort
+    ])
     this.loading$ = this.loading.asObservable()
     this.page$ = param$.pipe(
       switchMap(([query, sort]) => this.pageNumber.pipe(


### PR DESCRIPTION
It would be nice if this lib had debounceTime for queries, so typing wouldn't trigger too many requests to the server.

This is just a very simple implementation, it could be improved:

1) It could have an option to enable/disable debouncing.
2) There could be an option to choose which fields would be debounced.

I didn't venture on any of these options though because I like the way the usage on ts/html files is so simple. And setting 400ms as debounceTime is fast enough that anything other than typing wouldn't be an issue, in my opinion.